### PR TITLE
Fix license tag in Cabal file

### DIFF
--- a/groupoids.cabal
+++ b/groupoids.cabal
@@ -1,7 +1,7 @@
 name:          groupoids
 category:      Control, Categories
 version:       3.2
-license:       BSD3
+license:       BSD2
 cabal-version: >= 1.6
 license-file:  LICENSE
 author:        Edward A. Kmett


### PR DESCRIPTION
Synchronize the declared license with the de-facto one from https://github.com/ekmett/groupoids/commit/36e89f881aa3daaaf19d7cc15ca82c83ed31062a.